### PR TITLE
[Minor] If the merge exists, we shouldn't error.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -197,3 +197,4 @@ runs:
         name: ${{ steps.sanitised.outputs.name }}-merged-vex-statements
         path: ${{ runner.temp }}/${{ steps.sanitised.outputs.name }}-merged.openvex.json
         retention-days: 30
+        overwrite: true


### PR DESCRIPTION
To avoid this problem:
https://github.com/telicent-oss/telicent-base-images/actions/runs/15555405248/job/43794882132

This is due to the trivy action being called _after_ grype which have the same merge file names. 

Will address this later. Probably. _Possibly_.