### PR TITLE
fix: Delete temp remote vex dir before recreating it

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
       shell: bash
       run: |
         # Use runner temporary directory to download Remote VEX statements
-        mkdir ${RUNNER_TEMP}/.remote-vex
+        rm -rf ${RUNNER_TEMP}/.remote-vex && mkdir ${RUNNER_TEMP}/.remote-vex
         pushd ${RUNNER_TEMP}/.remote-vex
 
         # Create an empty Git repository


### PR DESCRIPTION
Jira ticket: https://telicent.atlassian.net/browse/TELDEVOPS-958

--

For the updated workflows for repositories in OSS, the Grype scan the is run following the build/push of an image to Quay is failing.

```shell
mkdir: cannot create directory ‘/home/runner/work/_temp/.remote-vex’: File exists
```

Examples
* https://github.com/telicent-oss/telicent-user-portal/actions/runs/19768235243
* https://github.com/telicent-oss/catalogue/actions/runs/19820845806
* https://github.com/telicent-oss/telicent-query/actions/runs/19761523347

## Issue

The Merge Remote VEX action attempts to create a new temporary directory in which VEX files are output. However, this directory was already created by the Trivy image scan, so the mkdir command fails, causing the workflow to fail.