### PR TITLE
Add caching of vexctl

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule: 
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5

--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -188,13 +188,13 @@ jobs:
 
       - name: Merging Local VEX Statements the first time
         id: first-vex-merge
-        uses: telicent-oss/merge-vex-action@cache-vexctl
+        uses: telicent-oss/merge-vex-action@v1
         with:
           name: first-merge
 
       - name: Merging Local VEX Statements again
         id: second-vex-merge
-        uses: telicent-oss/merge-vex-action@cache-vexctl
+        uses: telicent-oss/merge-vex-action@v1
         with:
           name: seconds-merge
 
@@ -241,7 +241,7 @@ jobs:
 
       - name: Merging Local VEX Statements the first time
         id: first-vex-merge
-        uses: telicent-oss/merge-vex-action@cache-vexctl
+        uses: telicent-oss/merge-vex-action@v1
         with:
           name: another-merge
           

--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -7,6 +7,9 @@ on:
       - "**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   local-only:

--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -177,3 +177,72 @@ jobs:
             exit 1
           fi
 
+  vexctl-caching:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: telicent-oss/telicent-base-images
+          ref: main
+
+      - name: Merging Local VEX Statements the first time
+        id: first-vex-merge
+        uses: telicent-oss/merge-vex-action@cache-vexctl
+        with:
+          name: first-merge
+
+      - name: Merging Local VEX Statements again
+        id: second-vex-merge
+        uses: telicent-oss/merge-vex-action@cache-vexctl
+        with:
+          name: seconds-merge
+
+      - name: Verify vexctl at expected location
+        shell: bash
+        run: |
+          if [ ! -f "${{ runner.temp }}/.vexctl/vexctl" ]; then
+            echo "::error::vexctl not installed at expected location"
+            exit 1
+          fi
+
+      - name: Check if vexctl is cached
+        id: check-cache
+        uses: actions/cache@v5
+        with:
+          key: vexctl-0.3.0-${{ runner.os }}-${{ runner.arch }}
+          path: ${{ runner.temp }}/.vexctl
+          lookup-only: true
+
+      - name: Fail if vexctl not cached
+        if: ${{ steps.check-cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          echo "::error::vexctl not cached for future reuse"
+          exit 1
+
+  vexctl-caching-reuse:
+    needs: [ vexctl-caching ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if vexctl is cached
+        id: check-cache
+        uses: actions/cache@v5
+        with:
+          key: vexctl-0.3.0-${{ runner.os }}-${{ runner.arch }}
+          path: ${{ runner.temp }}/.vexctl
+          lookup-only: true
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: telicent-oss/telicent-base-images
+          ref: main
+
+      - name: Merging Local VEX Statements the first time
+        id: first-vex-merge
+        uses: telicent-oss/merge-vex-action@cache-vexctl
+        with:
+          name: another-merge
+          
+

--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -239,8 +239,7 @@ jobs:
           repository: telicent-oss/telicent-base-images
           ref: main
 
-      - name: Merging Local VEX Statements the first time
-        id: first-vex-merge
+      - name: Merging Local VEX Statements the third time
         uses: telicent-oss/merge-vex-action@v1
         with:
           name: another-merge

--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ directory exists on that branch then a build warning is issued e.g.
 This warning is issued regardless of the reason for failure e.g. bad [Token Permissions](#github-token-permissions), no
 `.vex/` directory in remote repository etc.
 
+## `vexctl` Caching
+
+From `v1.1.0` onwards this action caches the `vexctl` executable in the GitHub Actions cache in order to speed up builds
+and address some build flakiness that manifests as intermittent failures installing the `vexctl` binary.
+
+Also if you invoke this action more than once in the same job the `vexctl` executable installed/restored from cache by
+earlier job steps will be reused rather than installing/restoring from cache again.
+
 # Inputs
 
 | Input | Required? | Default | Purpose |

--- a/action.yml
+++ b/action.yml
@@ -74,10 +74,46 @@ runs:
       run: |
         echo "name=$(echo '${{ inputs.name }}' | sed 's/[:/<>|*?\]/-/g' | tr -s '-')" >> $GITHUB_OUTPUT
 
-    - name: Setup vexctl
-      uses: openvex/setup-vexctl@main
+    - name: Is vexctl already installed?
+      id: install-check
+      shell: bash
+      run: |
+        if command -v vexctl; then
+          echo "vexctl already installed by a previous job step"
+          echo "installed=true" >> $GITHUB_OUTPUT
+        else
+          echo "installed=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Restore vexctl from Cache
+      id: vexctl-cache
+      if: ${{ steps.install-check.outputs.installed == 'false' }}
+      uses: actions/cache/restore@v5
+      with:
+        key: vexctl-0.3.0-${{ runner.os }}-${{ runner.arch }}
+        path: ${{ runner.temp }}/.vexctl
+        
+    - name: Add restored vexctl to path
+      if: ${{ steps.install-check.outputs.installed == 'false' && steps.vexctl-cache.outputs.cache-hit == 'true' }}
+      shell: bash
+      run: |
+        echo "Using previously installed vexctl from cache"
+        echo "${{ runner.temp }}/.vexctl/" >> $GITHUB_PATH
+
+    - name: Install vexctl if missing
+      id: install-vexctl
+      uses: openvex/setup-vexctl@a19bcb1ebb239098adfbb0f18624a09d253a2a4d
+      if: ${{ steps.install-check.outputs.installed == 'false' && steps.vexctl-cache.outputs.cache-hit != 'true' }}
       with:
         vexctl-release: '0.3.0'
+        install-dir: ${{ runner.temp }}/.vexctl
+
+    - name: Cache Vexctl for future reuse
+      if: ${{ steps.install-vexctl.outcome == 'success' }}
+      uses: actions/cache/save@v5
+      with:
+        key: vexctl-0.3.0-${{ runner.os }}-${{ runner.arch }}
+        path: ${{ runner.temp }}/.vexctl
 
     - name: Download Remote VEX Statements
       if: ${{ inputs.remote-vex != '' }}


### PR DESCRIPTION
This PR adds caching of the `vexctl` binary to the action so that once the action has run once in a repository it doesn't need to reinstall `vexctl` each time

Also pins the `setup-vexctl` action to a SHA hash and adds Dependant for GitHub Actions

This should provide some mild improvement to build times and also reduce the occurrence of intermittent build failures we sometimes see when trying to install `vexctl`